### PR TITLE
Feature/trocando para redshift serverless

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -23,23 +23,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:e61f064190045b5bd982fefa59de9f342fb07f8407d6cfa4aa39c370b93d2117",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.5.1"
-  constraints = ">= 3.5.1"
-  hashes = [
-    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
-    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
-    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
-    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
-    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
-    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
-    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
-    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
-    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
-    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
-    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
-  ]
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,9 @@
+variable "zone" {
+  description = "Zona de servidores que ficará provisionada a infraestrutura"
+  type        = string
+  default     = "us-east-1"
+}
+
 variable "vpc_cidr" {
   description = "IPv4 para a VPC"
   type        = string
@@ -28,6 +34,12 @@ variable "redshift_subnet_cidr_second" {
   default     = "10.0.2.0/24"
 }
 
+variable "redshift_subnet_cidr_third" {
+  description = "IPv4 para a segunda subnet"
+  type        = string
+  default     = "10.0.3.0/24"
+}
+
 variable "rs_cluster_identifier" {
   description = "Nome do cluster Redshift"
   type        = string
@@ -46,14 +58,8 @@ variable "rs_master_username" {
   default     = "redshift_user"
 }
 
-variable "rs_nodetype" {
-  description = "Tipo do nó do cluster"
+variable "rs_master_password" {
+  description = "Senha do banco de dados"
   type        = string
-  default     = "dc2.large"
-}
-
-variable "rs_cluster_type" {
-  description = "Tipo do cluster"
-  type        = string
-  default     = "single-node"
+  default     = "SenhaTeste1!"
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -2,7 +2,12 @@ terraform {
   required_version = ">=0.13.1"
 
   required_providers {
-    aws    = ">=4.63.0"
-    random = ">=3.5.1"
+    aws = ">=4.63.0"
+  }
+
+  backend "s3" {
+    bucket = "desafio-ton-redshift-tfstate-repository"
+    key    = "terraform.tfstate"
+    region = "us-east-1"
   }
 }


### PR DESCRIPTION
# Descrição

Foi trocado o servidor provisionado do Redshift para o modelo serverless, que é onde tem os créditos gratuitos que a AWS disponibiliza. Também foi criado a configuração para que o tfstate fique hospedado remotamente e não tenha problema de perder esse arquivo localmente.

# Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autorrevisão do meu próprio código
- [x] Comentei meu código, principalmente em áreas difíceis de entender
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos avisos
- [x] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream