### PR TITLE
feat: Adicionando id único para as transações na staging

### DIFF
--- a/models/staging/stone/_stone__models.yml
+++ b/models/staging/stone/_stone__models.yml
@@ -4,13 +4,19 @@ models:
   - name: stg_stone__transacoes
     description: teste
     columns:
+      - name: id_surrogate_key
+        description: Código único gerado pelas colunas id_codigo_transacao e id_codigo_usuario
+        tests:
+          - unique
+          - not_null
+
       - name: id_codigo_transacao
         description: Código único da transação
         tests:
           - not_null
 
-      - name: dt_transacao
-        description: Data e hora da transação (UTC 0)
+      - name: id_codigo_usuario
+        description: Código único do usuário
         tests:
           - not_null
 
@@ -41,16 +47,6 @@ models:
               values:
                 ["refused", "chargedback", "refunded", "processing", "paid"]
 
-      - name: nm_valor_transacao
-        description: Valor da transação (R$)
-        tests:
-          - not_null
-
-      - name: id_codigo_usuario
-        description: Código único do usuário
-        tests:
-          - not_null
-
       - name: nm_estado_usuario
         description: Estado do usuário
         tests:
@@ -58,5 +54,15 @@ models:
 
       - name: nm_cidade_usuario
         description: Cidade do usuário
+        tests:
+          - not_null
+
+      - name: nm_valor_transacao
+        description: Valor da transação (R$)
+        tests:
+          - not_null
+
+      - name: dt_transacao
+        description: Data e hora da transação (UTC 0)
         tests:
           - not_null

--- a/models/staging/stone/stg_stone__transacoes.sql
+++ b/models/staging/stone/stg_stone__transacoes.sql
@@ -7,6 +7,7 @@ WITH source AS (
 transacoes AS (
     SELECT
         -- ids
+        {{ dbt_utils.generate_surrogate_key(['codigo_da_transacao', 'codigo_do_usuario', 'data_e_hora_da_transacao']) }} AS id_surrogate_key, -- noqa: LT01, LT05
         codigo_da_transacao AS id_codigo_transacao,
         codigo_do_usuario AS id_codigo_usuario,
         -- strings


### PR DESCRIPTION
# Descrição

Utilizando a função `dbt_utils.generate_surrogate_key` para criar uma chave única para cada transação.

# Como isso foi testado?

- [x] Unique tests
- [x] Not null tests

# Checklist:

- [x] Meu código segue as diretrizes de estilo deste projeto
- [x] Realizei uma autorrevisão do meu próprio código
- [x] Comentei meu código, principalmente em áreas difíceis de entender
- [x] Fiz alterações correspondentes na documentação
- [x] Minhas alterações não geram novos avisos
- [x] Quaisquer alterações dependentes foram mescladas e publicadas em módulos downstream